### PR TITLE
[004-LOGIN-CUSTOMER] 커스터머에 대한 로그인 구현

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'cms'
 include 'user-api'
+include 'zerobase-domain'
 

--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -5,6 +5,9 @@ plugins {
 
 }
 
+bootJar{enabled = false}
+jar{enabled = true}
+
 group 'com.zerobase'
 version '0.0.1-SNAPSHOT'
 
@@ -22,6 +25,7 @@ configurations {
 }
 
 dependencies {
+    implementation project(path: ":zerobase-domain", configuration: 'default')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/user-api/src/main/java/com/zerobase/cms/user/UserApplication.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/UserApplication.java
@@ -1,13 +1,19 @@
 package com.zerobase.cms.user;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@ServletComponentScan
 @EnableFeignClients
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableJpaRepositories
+@RequiredArgsConstructor
 public class UserApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserApplication.class, args);

--- a/user-api/src/main/java/com/zerobase/cms/user/application/SignInApplication.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/application/SignInApplication.java
@@ -1,0 +1,29 @@
+package com.zerobase.cms.user.application;
+
+import com.zerobase.cms.user.domain.SignInForm;
+import com.zerobase.cms.user.domain.model.Customer;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
+import com.zerobase.cms.user.service.CustomerService;
+import com.zerobase.domain.common.UserType;
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignInApplication {
+
+    private final CustomerService customerService;
+    private final JwtAuthenticationProvider provider;
+
+    public String customerLoginToken(SignInForm form) {
+        // 1. 로그인 가능 여부
+        Customer c = customerService.findValidCustomer(form.getEmail(), form.getPassword())
+            .orElseThrow(() -> new CustomException(ErrorCode.LOGIN_CHECK_FAIL));
+        // 2. 토큰을 발행하고
+
+        // 3. 토큰을 response한다.
+        return provider.createToken(c.getEmail(), c.getId(), UserType.CUSTOMER);
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/config/JwtConfig.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/config/JwtConfig.java
@@ -1,0 +1,14 @@
+package com.zerobase.cms.user.config;
+
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider() {
+        return new JwtAuthenticationProvider();
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/config/filter/CustomerFilter.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/config/filter/CustomerFilter.java
@@ -1,0 +1,38 @@
+package com.zerobase.cms.user.config.filter;
+
+import com.zerobase.cms.user.service.CustomerService;
+import com.zerobase.domain.common.UserVo;
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@WebFilter(urlPatterns = "/customer/*")
+@RequiredArgsConstructor
+public class CustomerFilter implements Filter {
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final CustomerService customerService;
+
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        String token = req.getHeader("X-AUTH-TOKEN");
+        if (!jwtAuthenticationProvider.validateToken(token)) {
+            throw new ServletException("Invalid Access");
+        }
+        UserVo vo = jwtAuthenticationProvider.getUserVo(token);
+        customerService.findByIdAndEmail(vo.getId(), vo.getEmail()).orElseThrow(
+            () -> new ServletException("Invalid access")
+        );
+        chain.doFilter(request, response);
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/controller/CustomerController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/controller/CustomerController.java
@@ -1,0 +1,33 @@
+package com.zerobase.cms.user.controller;
+
+import com.zerobase.cms.user.domain.customer.CustomerDto;
+import com.zerobase.cms.user.domain.model.Customer;
+import com.zerobase.cms.user.domain.repository.CustomerRepository;
+import com.zerobase.cms.user.exception.CustomException;
+import com.zerobase.cms.user.exception.ErrorCode;
+import com.zerobase.cms.user.service.CustomerService;
+import com.zerobase.domain.common.UserVo;
+import com.zerobase.domain.config.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/customer")
+@RequiredArgsConstructor
+public class CustomerController {
+
+    private final JwtAuthenticationProvider provider;
+    private final CustomerService customerService;
+
+    @GetMapping("/getInfo")
+    public ResponseEntity<CustomerDto> getInfo(@RequestHeader(name = "X-AUTH-TOKEN") String token) {
+        UserVo vo = provider.getUserVo(token);
+        Customer c = customerService.findByIdAndEmail(vo.getId(), vo.getEmail()).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        return ResponseEntity.ok(CustomerDto.from(c));
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/controller/SignInController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/controller/SignInController.java
@@ -1,0 +1,23 @@
+package com.zerobase.cms.user.controller;
+
+import com.zerobase.cms.user.application.SignInApplication;
+import com.zerobase.cms.user.domain.SignInForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/signIn")
+@RequiredArgsConstructor
+public class SignInController {
+
+    private final SignInApplication signInApplication;
+
+    @PostMapping("/customer")
+    public ResponseEntity<String> signInCustomer(@RequestBody SignInForm form) {
+        return ResponseEntity.ok(signInApplication.customerLoginToken(form));
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/domain/SignInForm.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/domain/SignInForm.java
@@ -1,0 +1,9 @@
+package com.zerobase.cms.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public class SignInForm {
+    private String email;
+    private String password;
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/domain/customer/CustomerDto.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/domain/customer/CustomerDto.java
@@ -1,0 +1,19 @@
+package com.zerobase.cms.user.domain.customer;
+
+import com.zerobase.cms.user.domain.model.Customer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CustomerDto {
+
+    private Long id;
+    private String email;
+
+    public static CustomerDto from(Customer customer) {
+        return new CustomerDto(customer.getId(), customer.getEmail());
+    }
+}

--- a/user-api/src/main/java/com/zerobase/cms/user/domain/repository/CustomerRepository.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/domain/repository/CustomerRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Optional<Customer> findByEmail(String email);
+
 }

--- a/user-api/src/main/java/com/zerobase/cms/user/exception/ErrorCode.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/exception/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 회원이 없습니다."),
     ALREADY_VERIFY(HttpStatus.BAD_REQUEST, "이미 인증이 완료되었습니다."),
     WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다."),
-    EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다.");
+    EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다."),
+
+    // login
+    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디나 패스워드를 확인해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/user-api/src/main/java/com/zerobase/cms/user/exception/ExceptionController.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/exception/ExceptionController.java
@@ -1,5 +1,6 @@
 package com.zerobase.cms.user.exception;
 
+import javax.servlet.ServletException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -18,7 +19,6 @@ public class ExceptionController {
         log.warn("api Exception : {}", c.getErrorCode());
         return ResponseEntity.badRequest().body(new ExceptionResponse(c.getMessage(), c.getErrorCode()));
     }
-
 
     @Getter
     @ToString

--- a/user-api/src/main/java/com/zerobase/cms/user/service/CustomerService.java
+++ b/user-api/src/main/java/com/zerobase/cms/user/service/CustomerService.java
@@ -1,0 +1,25 @@
+package com.zerobase.cms.user.service;
+
+import com.zerobase.cms.user.domain.model.Customer;
+import com.zerobase.cms.user.domain.repository.CustomerRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerService {
+    private final CustomerRepository customerRepository;
+
+    public Optional<Customer> findByIdAndEmail(Long id, String email) {
+        return customerRepository.findById(id)
+            .stream().filter(customer -> customer.getEmail().equals(email))
+            .findFirst();
+    }
+
+    public Optional<Customer> findValidCustomer(String email, String password) {
+        return customerRepository.findByEmail(email).stream()
+            .filter(customer -> customer.getPassword().equals(password) && customer.isVerify())
+            .findFirst();
+    }
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/common/UserType.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/common/UserType.java
@@ -1,0 +1,5 @@
+package com.zerobase.domain.common;
+
+public enum UserType {
+    CUSTOMER,SELLER,
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/common/UserVo.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/common/UserVo.java
@@ -1,0 +1,13 @@
+package com.zerobase.domain.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserVo {
+
+    private Long id;
+    private String email;
+
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/config/JwtAuthenticationProvider.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/config/JwtAuthenticationProvider.java
@@ -1,0 +1,42 @@
+package com.zerobase.domain.config;
+
+import com.zerobase.domain.common.UserVo;
+import com.zerobase.domain.common.UserType;
+import com.zerobase.domain.util.Aes256Util;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+
+public class JwtAuthenticationProvider {
+    private String secretKey = "secretKey";
+
+    private long tokenValidTime = 1000L * 60 * 60 * 24;
+
+    public String createToken(String userPk, Long id, UserType userType) {
+        Claims claims = Jwts.claims().setSubject(Aes256Util.encrypt(userPk)).setId(Aes256Util.encrypt(id.toString()));
+        claims.put("roles",userType);
+        Date now = new Date();
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() +tokenValidTime))
+            .signWith(SignatureAlgorithm.HS256, secretKey)
+            .compact();
+    }
+
+    public boolean validateToken(String jwtToken) {
+        try{
+            Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return !claimsJws.getBody().getExpiration().before(new Date());
+        }catch (Exception e){
+            return false;
+        }
+    }
+
+    public UserVo getUserVo(String token) {
+        Claims c = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        return new UserVo(Long.valueOf(Aes256Util.decrypt(c.getId())), Aes256Util.decrypt(c.getSubject()));
+    }
+}

--- a/zerobase-domain/src/main/java/com/zerobase/domain/util/Aes256Util.java
+++ b/zerobase-domain/src/main/java/com/zerobase/domain/util/Aes256Util.java
@@ -1,0 +1,42 @@
+package com.zerobase.domain.util;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.tomcat.util.codec.binary.Base64;
+
+public class Aes256Util {
+    public static String alg = "AES/CBC/PKCS5Padding";
+    private static final String KEY = "ZEROBASEKEYISZEROBASEKEY";
+    private static final String IV = KEY.substring(0, 16);
+
+    public static String encrypt(String text) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.ENCRYPT_MODE,keySpec,ivParameterSpec);
+
+            byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+            return Base64.encodeBase64String(encrypted);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static String decrypt(String cipherText) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(KEY.getBytes(), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(IV.getBytes(StandardCharsets.UTF_8));
+            cipher.init(Cipher.DECRYPT_MODE,keySpec,ivParameterSpec);
+
+            byte[] decodedBytes = Base64.decodeBase64(cipherText);
+            byte[] decrypted = cipher.doFinal(decodedBytes);
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/zerobase-domain/src/test/java/com/zerobase/domain/util/Aes256UtilTest.java
+++ b/zerobase-domain/src/test/java/com/zerobase/domain/util/Aes256UtilTest.java
@@ -1,0 +1,16 @@
+package com.zerobase.domain.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class Aes256UtilTest {
+
+    @Test
+    void encrypt() {
+        String encrypt = Aes256Util.encrypt("Hello world");
+        assertEquals(Aes256Util.decrypt(encrypt), "Hello world");
+    }
+
+}


### PR DESCRIPTION
Changes
---

1. 로그인을 통한 토큰 발행
2. /customer/* 에 대한 token filter 적용

Background
---
JWT에 대해 공부한 내용
WebFilter를 통해 header token 검증을 하였음

교훈
---
실수를 하지 말자.